### PR TITLE
Update to PostCSS 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,16 @@ module.exports = postcss.plugin('postcss-opacity', function (opts) {
 
   return function (css) {
 
-    css.eachRule(function (rule) {
+    css.walkRules(function (rule) {
 
       // find if a filter opacity is already present
       var isFilterAlreadyPresent = false;
-      rule.eachDecl(PROP_REPLACE, function () {
+      rule.walkDecls(PROP_REPLACE, function () {
         isFilterAlreadyPresent = true;
       });
 
       if (!isFilterAlreadyPresent) {
-        rule.eachDecl(PROP, function (decl) {
+        rule.walkDecls(PROP, function (decl) {
 
           // get amount and create value
           var amount = Math.floor(decl.value * 100);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-opacity",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "PostCSS plugin to add opacity filter for IE8",
   "keywords": [
     "postcss",
@@ -15,7 +15,7 @@
     "url": "https://github.com/iamvdo/postcss-opacity.git"
   },
   "dependencies": {
-    "postcss": "^4.1.16"
+    "postcss": "^5.0.4"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Updates PostCSS to v5
Updates syntax as eachRule and eachDecl was deprecated in favor of walkRules walkDecls
Bumps package version

Thank you for making this plugin. It’s a must-have when I support IE8.
